### PR TITLE
fix: renamed master to main

### DIFF
--- a/resurser/da395a-vt24/6-utvecklingsmetodik/i1.md
+++ b/resurser/da395a-vt24/6-utvecklingsmetodik/i1.md
@@ -519,7 +519,7 @@ Vi har nu en fil som finns i vår *arbetskopia*, men som ännu inte är versions
 
 ``` bash
 $ git status
-På grenen master
+På grenen main
 
 Inga incheckningar ännu
 
@@ -536,7 +536,7 @@ Säg till git att börja versionshantera filen genom att använda `git add`:
 ```bash
 $ git add vogonpoesi.txt
 $ git status
-På grenen master
+På grenen main
 
 Inga incheckningar ännu
 
@@ -552,11 +552,11 @@ Slutligen vill vi *checka in* filen så att den verkligen sparas som en *revisio
 
 ``` bash
 $ git commit -m "Lite vogonpoesi"
-[master (rotincheckning) e6404b2] Lite vogonpoesi
+[main (rotincheckning) e6404b2] Lite vogonpoesi
   1 file changed, 5 insertions(+)
   create mode 100644 vogonpoesi.txt
 $ git status
-På grenen master
+På grenen main
 inget att checka in, arbetskatalogen ren
 ```
 
@@ -587,7 +587,7 @@ Oerhört vackert. Dock, inget som vi vill versionshantera. Git kommer dock att t
 
 ```bash
 $ git status
-På grenen master
+På grenen main
 Ospårade filer:
   (använd "git add <fil>..." för att ta med i det som skall checkas in)
 
@@ -614,7 +614,7 @@ Om vi nu kör en `git status` kommer git inte längre tycka att du ska versionsh
 
 ``` bash
 $ git status
-På grenen master
+På grenen main
 Ospårade filer:
   (använd "git add <fil>..." för att ta med i det som skall checkas in)
 
@@ -628,7 +628,7 @@ Nu kan vi lägga till *.gitignore* och undvika att lägga till *boye.txt* genom 
 ``` bash
 $ git add .
 $ git status
-På grenen master
+På grenen main
 Ändringar att checka in:
   (använd "git reset HEAD <fil>..." för att ta bort från kö)
 
@@ -653,7 +653,7 @@ Du gör förstås vilken förändring du vill. Det spelar ingen roll vad du gör
 
 ``` bash
 $ git status
-På grenen master
+På grenen main
 Ändringar ej i incheckningskön:
   (använd "git add <fil>..." för att uppdatera vad som skall checkas in)
   (använd "git checkout -- <fil>..." för att förkasta ändringar i arbetskatalogen)
@@ -668,7 +668,7 @@ Lägg till och checka in förändringarna:
 ``` bash
 $ git add .
 $ git commit -m "Förbättrade vogonpoesin"
-[master 9af0168] Förbättrade vogonpoesin
+[main 9af0168] Förbättrade vogonpoesin
   1 file changed, 2 insertions(+)
 ```
 
@@ -682,11 +682,11 @@ Ponera att du får en potentiellt fantastisk idé kring hur du ska förbättra p
 $ git branch nytt_infall
 ```
 
-Kommandot skapar en ny gren, som vi döper till *nytt_infall*. Märk väl att du fortfarande är kvar på grenen *master*, vilket vi ser om vi kör `git status`:
+Kommandot skapar en ny gren, som vi döper till *nytt_infall*. Märk väl att du fortfarande är kvar på grenen *main*, vilket vi ser om vi kör `git status`:
 
 ``` bash
 $ git status
-På grenen master
+På grenen main
 inget att checka in, arbetskatalogen ren
 ```
 
@@ -714,11 +714,11 @@ $ git commit -m "Lade till två nya rader poesi"
 
 Säkerställ att allt är rätt genom att köra `git status`.
 
-Växla tillbaka till grenen *master*:
+Växla tillbaka till grenen *main*:
 
 ``` bash
-$ git checkout master
-Växlade till grenen "master"
+$ git checkout main
+Växlade till grenen "main"
 ```
 
 Öppna *vogonpoesi.txt* i din texteditor. Lägg märke till att de två raderna som vi nyss skrev är borta.
@@ -732,7 +732,7 @@ Nu inser vi att den första raden i originaldikten inte har riktigt rätt klang.
 ``` bash
 $ git add .
 $ git commit -m "Perfektion."
-[master 36cdbdf] Perfektion.
+[main 36cdbdf] Perfektion.
   1 file changed, 1 insertion(+), 1 deletion(-)
 ```
 
@@ -740,7 +740,7 @@ Nu har vi två versioner av samma dikt. Bra, fast vill vi egentligen inte slå s
 
 #### Slå samman två grenar
 
-Det är klart att vi vill! Som tur är, är git väldigt bra på att göra det. Vi använder kommandot `git merge` för att slå samman dem. Säkerställ att du står på grenen *master* och skriv sedan
+Det är klart att vi vill! Som tur är, är git väldigt bra på att göra det. Vi använder kommandot `git merge` för att slå samman dem. Säkerställ att du står på grenen *main* och skriv sedan
 
 ``` bash
 $ git merge nytt_infall
@@ -778,7 +778,7 @@ Slutligen vill vi ta bort dikten. Det är ju trots allt riktigt dålig. Vi tar b
 ``` bash
 $ rm vogonpoesi.txt
 $ git status
-På grenen master
+På grenen main
 Ändringar ej i incheckningskön:
   (använd "git add/rm <fil>..." för att uppdatera vad som skall checkas in)
   (använd "git checkout -- <fil>..." för att förkasta ändringar i arbetskatalogen)
@@ -793,14 +793,14 @@ I vanlig ordning måste vi checka in vår förändring:
 ``` bash
 $ git add .
 $ git status
-På grenen master
+På grenen main
 Ändringar att checka in:
   (använd "git reset HEAD <fil>..." för att ta bort från kö)
 
         borttagen:     vogonpoesi.txt
 
 $ git commit -m "Tog bort den fruktansvärda dikten"
-master d9aacf2] Tog bort den fruktansvärda dikten
+main d9aacf2] Tog bort den fruktansvärda dikten
   1 file changed, 9 deletions(-)
   delete mode 100644 vogonpoesi.txt
 ```
@@ -813,7 +813,7 @@ Ja, vad hände? Vi skrev en dikt som vi versionshanterade och skrev en till som 
 
 ``` bash
 $ git log
-commit d9aacf2073de42268fb6348d7cdcddfe2c16d022 (HEAD -> master)
+commit d9aacf2073de42268fb6348d7cdcddfe2c16d022 (HEAD -> main)
 Author: Johan Holmberg <johan@idioti.se>
 Date:   Thu May 9 01:51:49 2019 +0200
 
@@ -861,7 +861,7 @@ Vackert, men svårläst. Vi kan även få git att rita en fin *graf* åt oss. L�
 
 ``` bash
 $ git log --graph
-* commit d9aacf2073de42268fb6348d7cdcddfe2c16d022 (HEAD -> master)
+* commit d9aacf2073de42268fb6348d7cdcddfe2c16d022 (HEAD -> main)
 | Author: Johan Holmberg <johan@idioti.se>
 | Date:   Thu May 9 01:51:49 2019 +0200
 | 
@@ -994,7 +994,7 @@ remote: Compressing objects: 100% (3/3), done.
 remote: Total 3 (delta 0), reused 0 (delta 0), pack-reused 0
 Packar upp objekt: 100% (3/3), klart.
 Från https://github.com/koddas/testing-with-jest
-    baefd5d..496ecab  master     -> origin/master
+    baefd5d..496ecab  main     -> origin/main
 Uppdaterar baefd5d..496ecab
 Fast-forward
   README.md | 5 +++++
@@ -1016,7 +1016,7 @@ LICENSE  README.md
 ``` bash
 $ git add .
 $ git commit -m "Små förändringar till README.md"
-[master 30e2c10] Små förändringar till README.md
+[main 30e2c10] Små förändringar till README.md
   1 file changed, 1 insertion(+), 1 deletion(-)
 ```
 
@@ -1034,7 +1034,7 @@ Skriver objekt: 100% (3/3), 360 bytes | 360.00 KiB/s, klart.
 Total 3 (delta 2), reused 0 (delta 0)
 remote: Resolving deltas: 100% (2/2), completed with 2 local objects.
 To https://github.com/koddas/testing-with-jest
-    496ecab..30e2c10  master -> master
+    496ecab..30e2c10  main -> main
 ```
 
 Öppna din GitHub-sida, ladda om den och klicka på *README.md*. Säkerställ att dina förändringar finns där.
@@ -1152,8 +1152,8 @@ Vi ser att vi har en ny fil *package-lock.json*, som vi redan pratat om, och *no
 
 ``` bash
 $ git status
-På grenen master
-Din gren är à jour med "origin/master".
+På grenen main
+Din gren är à jour med "origin/main".
 
 Ospårade filer:
   (använd "git add <fil>..." för att ta med i det som skall checkas in)
@@ -1168,8 +1168,8 @@ Checka in förändringarna innan vi går vidare:
 
 ``` bash
 $ git add .
-$ git commmit -m "Lade till Underscore"
-[master 9faed26] Lade till Underscore
+$ git commit -m "Lade till Underscore"
+[main 9faed26] Lade till Underscore
   2 files changed, 35 insertions(+)
   create mode 100644 package-lock.json
   create mode 100644 package.json
@@ -1214,7 +1214,7 @@ När vi är klara checkar vi in förändringarna:
 ``` bash
 $ git add .
 $ git commit -m "Lade till Webpack"
-[master ab52a7f] Lade till Webpack
+[main ab52a7f] Lade till Webpack
   3 files changed, 4091 insertions(+)
   create mode 100644 webpack.config.js
 ```
@@ -1241,7 +1241,7 @@ Git-panelen är uppdelad i tre delar:
 * Staged Changes. Det här är de filer som blir grönmarkerade när du skriver `git status` i terminalen, vilket innebär att du kört `git add` på dem.
 * Message. Det här är incheckningsrutan. Skriv ditt incheckningsmeddelande och klicka på bocken för att checka in förändringarna till den nuvarande grenen´.
 
-Under Git-panelen finns två andra intressanta knappar: *master* och en synk-ikon. Om du klickar på *master* kan du skapa och växla mellan grenar. Klickar du på synk-ikonen kan du skicka dina förändringar till GitHub. Notera att de här knapparna byter text, beroende på vilken gren du står på och hur många incheckningar som inte skickats till GitHub än.
+Under Git-panelen finns två andra intressanta knappar: *main* och en synk-ikon. Om du klickar på *main* kan du skapa och växla mellan grenar. Klickar du på synk-ikonen kan du skicka dina förändringar till GitHub. Notera att de här knapparna byter text, beroende på vilken gren du står på och hur många incheckningar som inte skickats till GitHub än.
 
 ---
 


### PR DESCRIPTION
Updated so the instructions follow the new git versions' default branch name.