### PR TITLE
Added docstring req on module 6 assignment

### DIFF
--- a/resurser/da354b-ht24/6-webbapplikationer/assignment.md
+++ b/resurser/da354b-ht24/6-webbapplikationer/assignment.md
@@ -61,6 +61,9 @@ Exempelvideo och förtydligande av funktionalitet för betyget **G**:
 
 [Bottle](http://bottlepy.org/) är det rekommenderade ramverket på grund av enkelheten i att installera och komma igång. Enklast: ladda hem [`bottle.py`](http://bottlepy.org/bottle.py) till din projektmapp.
 
+#### Dokumentation
+
+Koden ska vara tydlig och lättläst med avseende på namngivning, strukturering och kommentarer. Funktioner ska ha en beskrivning i form av _docstrings_ (`"""Kommentar för funktionen"""`-kommentarer). För att få lite svar på vanliga frågor om docstrings, se [PEP 257](../../pep257).
 
 ### Bedömning
 


### PR DESCRIPTION
This pull request includes a small change to the documentation in the `assignment.md` file. The change adds a new section to emphasize the importance of clear and readable code with proper naming, structure, and comments, including the use of docstrings. 

Documentation improvements:

* [`resurser/da354b-ht24/6-webbapplikationer/assignment.md`](diffhunk://#diff-111fad037423a2d01761794a16099bcc3bf7fb5459521092588b442d4cf68e75R64-R66): Added a new "Dokumentation" section to emphasize the importance of clear and readable code with proper naming, structure, and comments, including the use of docstrings.