### PR TITLE
Ta bort döda länkar för inlämningsuppgift 5 (DA281A)

### DIFF
--- a/resurser/da281a/uppgifter/uppgift-5.md
+++ b/resurser/da281a/uppgifter/uppgift-5.md
@@ -26,7 +26,7 @@ Nyckelordet `this` används mycket i dessa sammanhang och därför är det vikti
 **React**
 
 * [Reacts startsida med quick start](https://react.dev/learn)
-* [Learn React In 30 Minutes](https://www.youtube.com/watch?v=hQAHSlTtcmY)(Obs: startfielrna är lite annorlunda men koden är fortfarande aktuell)
+* [Learn React In 30 Minutes](https://www.youtube.com/watch?v=hQAHSlTtcmY)(Obs: startfilerna är lite annorlunda men koden är fortfarande aktuell)
 * [React Tutorial](https://www.youtube.com/watch?v=jc9_Bqzy2YQ) (video)
 * [Allt om React](https://coenraets.org/react-js-tutorial-example/) (Se avsnitt 4.1, 4.2 och 4.3 för att göra en enkel React projekt)
 
@@ -38,7 +38,7 @@ För att ta ett kort exempel hade ni kunnat välja att göra en filmdatabas. Dä
 
 ## Kravspecifikation
 
-**Ni behöver inte placera all kod en en extern JavaScript fil.**
+**Ni behöver inte placera all kod i en extern JavaScript fil.**
 
 * På första raden i er fil ska ni använda raden `"use strict";` för att göra webbläsaren mer strikt i sin tolkning av er kod
 * Det får inte visas några felmeddelande i webbkonsollen
@@ -56,6 +56,6 @@ För att ta ett kort exempel hade ni kunnat välja att göra en filmdatabas. Dä
 
 **Glöm inte kontrollera att ni skickat med svar på alla uppgifter och att ni följt kravspecifikationen.**
 
-När du är färdig med din uppgift ska du ladda upp denna som en `.zip`-fil innehållande alla dina filer på Canvas. Döp denna enligt formatet `inl5_Förnamn_Efternamn.zip`. DU ska även ladda upp dessa filer på dvwebb och därefter ska du även inkludera länken dit.
+När du är färdig med din uppgift ska du ladda upp denna som en `.zip`-fil innehållande alla dina filer på Canvas. Döp denna enligt formatet `inl5_Förnamn_Efternamn.zip`. Du ska även ladda upp dessa filer på dvwebb och därefter ska du även inkludera länken dit.
 
 Lycka till!

--- a/resurser/da281a/uppgifter/uppgift-5.md
+++ b/resurser/da281a/uppgifter/uppgift-5.md
@@ -28,14 +28,7 @@ Nyckelordet `this` används mycket i dessa sammanhang och därför är det vikti
 * [Reacts startsida med quick start](https://react.dev/learn)
 * [Learn React In 30 Minutes](https://www.youtube.com/watch?v=hQAHSlTtcmY)(Obs: startfielrna är lite annorlunda men koden är fortfarande aktuell)
 * [React Tutorial](https://www.youtube.com/watch?v=jc9_Bqzy2YQ) (video)
-* [React videos](https://egghead.io/courses/react-fundamentals)
 * [Allt om React](https://coenraets.org/react-js-tutorial-example/) (Se avsnitt 4.1, 4.2 och 4.3 för att göra en enkel React projekt)
-
-
-**Extra**
-
-* [ES6](http://coenraets.org/present/es6/#22) (den nya syntaxen för JavaScript)
-* [React tutorial cloning Yelp](https://www.fullstackreact.com/articles/react-tutorial-cloning-yelp/)
 
 ## Uppgiften
 


### PR DESCRIPTION
Hej!

### Medan jag tittat igenom materialet har jag upptäckt tre döda länkar:

1. [React videos](https://egghead.io/courses/react-fundamentals) - 404, innehållet har tagits bort.
2. [ES6](http://coenraets.org/present/es6/#22) - Omdirigeras till `https://jsonviewer.ai/#22` som visar en JSON-visare, rimligtvis är det inte detta som länken är tänkt att leda till.
3. [React tutorial cloning Yelp](https://www.fullstackreact.com/articles/react-tutorial-cloning-yelp/) - Omdirigeras till en GoDaddy-sida där domänen är till salu.

Förmodar att dessa länkar helst ersätts av nya länkar som innehåller relevant material som nu saknas. Oavsett vilket känns det ju dumt att dirigera studenter helt galet till sidor som inte längre är tillgängliga eller som inte längre innehåller det ursprungliga materialet.

### Ej relevant till denna PR utan mer en kommentar till kursen som helhet:
Det är lite tråkigt att [React-övningen](https://mau-webb.github.io/resurser/da281a/material/react_exercise/) inte använder den "senaste" (känns som det var ett par år sedan det var nytt...) tekniken med hooks. Det kanske är på tiden att se över det materialet. Avundas inte studenter som aldrig jobbat med React tidigare, ser övningen och sedan kollar in YouTube-resurserna som helt plötsligt använder React med hooks istället för klasser. Men jag vet såklart inte vad er baktanke är med att utforma materialet så som ni gjort, och det kanske finns en bra anledning till att introducera React med klasser i övningen istället för med hooks.